### PR TITLE
Add param of bucket result

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ lane :test do
     # use_orchestrator: false,                                      # If you use orchestrator when set instrumentation test.
     console_log_file_name: "fastlane/console_output.log",           
     timeout: "3m",                                                  
-    firebase_test_lab_results_bucket: "firebase_cats_test_bucket",  # 
-    slack_url: ENV["SLACK_URL"],                                    # IF you want notify to Slack.
+    firebase_test_lab_results_bucket: "firebase_cats_test_bucket",  # If you want to naming bucket of GCS 
+    # firebase_test_lab_results_dir: "firebase_cats_test_dir",      # If you want to naming results of GCS. (Maybe don't need it.) 
+    slack_url: ENV["SLACK_URL"],                                    # If you want notify to Slack.
 
     # If you want notify to Github pull requests.
     github_owner: "******",                                         # Owner name. 

--- a/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
+++ b/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
@@ -12,12 +12,6 @@ module Fastlane
         results_bucket = params[:firebase_test_lab_results_bucket] == nil ? "#{params[:project_id]}_test_results" : params[:firebase_test_lab_results_bucket]
         results_dir = "firebase_test_result_#{DateTime.now.strftime('%Y-%m-%d-%H:%M:%S')}"
 
-        # Create the log file
-        dirname = File.dirname(params[:console_log_file_name])
-        unless File.directory?(dirname)
-          FileUtils.mkdir_p(dirname)
-        end
-
         # Set target project
         Helper.config(params[:project_id])
         # Activate service account
@@ -32,7 +26,7 @@ module Fastlane
                   "--results-bucket #{results_bucket} "\
                   "--results-dir #{results_dir} "\
                   "#{params[:extra_options]} "\
-                  "--format=json 1>#{params[:console_log_file_name]}"
+                  "--format=json 1>#{Helper.if_need_dir(params[:console_log_file_name])}"
         )
 
         # Sample data

--- a/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
+++ b/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
@@ -9,8 +9,8 @@ module Fastlane
       def self.run(params)
         UI.message("Starting...")
 
-        results_bucket = params[:firebase_test_lab_results_bucket] == nil ? "#{params[:project_id]}_test_results" : params[:firebase_test_lab_results_bucket]
-        results_dir = "firebase_test_result_#{DateTime.now.strftime('%Y-%m-%d-%H:%M:%S')}"
+        results_bucket = params[:firebase_test_lab_results_bucket] || "#{params[:project_id]}_test_results"
+        results_dir = params[:firebase_test_lab_results_dir] || "firebase_test_result_#{DateTime.now.strftime('%Y-%m-%d-%H:%M:%S')}"
 
         # Set target project
         Helper.config(params[:project_id])
@@ -169,6 +169,12 @@ module Fastlane
          FastlaneCore::ConfigItem.new(key: :firebase_test_lab_results_bucket,
                                       env_name: "FIREBASE_TEST_LAB_RESULTS_BUCKET",
                                       description: "Name of Firebase Test Lab results bucket",
+                                      type: String,
+                                      optional: true,
+                                      default_value: nil),
+         FastlaneCore::ConfigItem.new(key: :firebase_test_lab_results_dir,
+                                      env_name: "FIREBASE_TEST_LAB_RESULTS_DIR",
+                                      description: "Name of Firebase Test Lab results directory",
                                       type: String,
                                       optional: true,
                                       default_value: nil),

--- a/lib/fastlane/plugin/firebase_test_lab_android/helper/Helper.rb
+++ b/lib/fastlane/plugin/firebase_test_lab_android/helper/Helper.rb
@@ -41,6 +41,15 @@ module Fastlane
       outcome == FAILED || outcome == INCONCLUSIVE
     end
 
+    def self.if_need_dir(path)
+      dirname = File.dirname(params[:console_log_file_name])
+      unless File.directory?(dirname)
+        UI.message("Crate directory: #{dirname}")
+        FileUtils.mkdir_p(dirname)
+      end
+      path
+    end
+
     def self.format_device_name(axis_value)
       # Sample Nexus6P-23-ja_JP-portrait
       array = axis_value.split("-")

--- a/lib/fastlane/plugin/firebase_test_lab_android/version.rb
+++ b/lib/fastlane/plugin/firebase_test_lab_android/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseTestLabAndroid
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
# Changes

- Add param for test lab result dir settings of GCS bucket.
- Bug fixed bug can not make a log file when does not exist parent dir.