### PR TITLE
Add option to prevent result from being published

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
+++ b/lib/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action.rb
@@ -53,7 +53,9 @@ module Fastlane
             axis = status["axis_value"]
             Helper.if_need_dir("#{download_dir}/#{axis}")
             Helper.copy_from_gcs("#{results_bucket}/#{results_dir}/#{axis}", download_dir)
-            Helper.set_public("#{results_bucket}/#{results_dir}/#{axis}")
+            if params[:publish_result]
+              Helper.set_public("#{results_bucket}/#{results_dir}/#{axis}")
+            end
           end
         end
 
@@ -236,7 +238,13 @@ module Fastlane
                                       description: "Target directory to download screenshots from firebase",
                                       type: String,
                                       optional: true,
-                                      default_value: nil)
+                                      default_value: nil),
+         FastlaneCore::ConfigItem.new(key: :publish_result,
+                                      env_name: "PUBLISH_RESULT",
+                                      description: "Set result's ACL to public (effective only if download_dir is set)",
+                                      type: Boolean,
+                                      optional: true,
+                                      default_value: true)
         ]
       end
 

--- a/spec/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action_spec.rb
+++ b/spec/fastlane/plugin/firebase_test_lab_android/actions/firebase_test_lab_android_action_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::FirebaseTestLabAndroidAction do
+  describe '.run' do
+    subject { described_class.run(params) }
+
+    before do
+      allow(Fastlane::Helper).to receive(:config)
+      allow(Fastlane::Helper).to receive(:authenticate)
+      allow(Fastlane::Helper).to receive(:run_tests)
+      allow(Fastlane::Helper).to receive(:if_need_dir)
+      allow(Fastlane::Helper).to receive(:copy_from_gcs)
+      allow(Fastlane::Helper).to receive(:set_public)
+      allow(Fastlane::Helper).to receive(:make_slack_text)
+      allow(Fastlane::Helper).to receive(:make_github_text)
+      allow(File).to receive(:read).with(params[:console_log_file_name]).and_return json
+    end
+
+    let(:params) do
+      {
+        project_id: 'test',
+        gcloud_service_key_file: 'test.json',
+        type: 'robo',
+        devices: [{
+          model: 'Nexus6',
+          version: '21',
+          locale: 'en_US',
+          orientation: 'portrait'
+        }],
+        app_apk: 'test.apk',
+        timeout: '3m',
+        use_orchestrator: false,
+        gcloud_components_channel: 'stable',
+        console_log_file_name: './console_output.log',
+        extra_options: '',
+        download_dir: "download",
+        publish_result: publish_result,
+      }
+    end
+
+    let(:json) do
+      <<~EOF
+      [
+        {
+          "axis_value": "Nexus6P-23-ja_JP-portrait",
+          "outcome": "Passed",
+          "test_details": "--"
+        },
+        {
+          "axis_value": "Pixel2-28-en_US-portrait",
+          "outcome": "Passed",
+          "test_details": "--"
+        }
+      ]
+      EOF
+    end
+
+    context 'with publish_result is true' do
+      let(:publish_result) { true }
+
+      it 'sets the specified GCS object to public-read ACL' do
+        expect(Fastlane::Helper).to receive(:set_public)
+        subject
+      end
+    end
+
+    context 'with publish_result is false' do
+      let(:publish_result) { false }
+
+      it 'does not manipulate ACL of the specified GCS object' do
+        expect(Fastlane::Helper).not_to receive(:set_public)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Close #20 

- Add new option `publish_result` to prevent GCS objects from being published
    - `publish_result` is `true` by default, to keep backward compatibility
- Add spec to describe the option's behavior